### PR TITLE
Fix stale warnings card persisting across uploads

### DIFF
--- a/src/ffis/static/index.html
+++ b/src/ffis/static/index.html
@@ -467,12 +467,16 @@
        ${checksum ? `<span>${checksum}</span>` : ''}`;
 
     // ── Warnings (plain English) ─────────────────────────────────────────────
+    const warningsCard = document.getElementById('warnings-card');
+    const wb = document.getElementById('warnings-body');
     if (d.warnings?.length) {
-      const wb = document.getElementById('warnings-body');
       wb.innerHTML = d.warnings.map(w =>
         `<div class="warning-item">${friendlyWarning(w.code, w.message)}</div>`
       ).join('');
-      document.getElementById('warnings-card').style.display = 'block';
+      warningsCard.style.display = 'block';
+    } else {
+      wb.innerHTML = '';
+      warningsCard.style.display = 'none';
     }
 
     // ── Tool breakdown — aligned table ───────────────────────────────────────


### PR DESCRIPTION
- The warnings card had no else branch, so once a file produced warnings it stayed visible
- Subsequent upload with no warnings still displayed the previous file's text.